### PR TITLE
Introduce `setupPredefinedEnvironmentListeners` to allow setup build-in environment listener

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests:
-    runs-on: macos-12
-    strategy:
-      matrix:
-        xcode: [13.3]
+  tests:  
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
       - name: install xcbeautify
         run: brew install xcbeautify
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Select Xcode Version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.2"  
       - name: Run tests
-        run: xcodebuild test -project ./XcodeProject/UIEnvironment.xcodeproj -destination platform="iOS Simulator,name=iPhone 11 Pro Max" -scheme "App" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcbeautify
+        run: xcodebuild test -project ./XcodeProject/UIEnvironment.xcodeproj -destination platform="iOS Simulator,name=iPhone 15 Pro Max" -scheme "App" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcbeautify

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout Package
         uses: actions/checkout@v2

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "libffi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/623637646/libffi.git",
+      "state" : {
+        "revision" : "bc1dac0c1b522539f21fc28fe1f7e07bb7c2fbd5",
+        "version" : "3.4.5"
+      }
+    },
+    {
+      "identity" : "swifthook",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/623637646/SwiftHook",
+      "state" : {
+        "revision" : "474f80132a3a4e74b3f8a5b87b707d74de387769",
+        "version" : "3.5.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,13 @@ let package = Package(
             targets: ["UIEnvironment"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/623637646/SwiftHook", from: "3.5.2")
     ],
     targets: [
         .target(
             name: "UIEnvironment",
-            dependencies: []),
+            dependencies: [
+                .product(name: "SwiftHook", package: "SwiftHook")
+            ]),
     ]
 )

--- a/Sources/UIEnvironment/Predefined Environment Keys/LocaleEnvironmentKey.swift
+++ b/Sources/UIEnvironment/Predefined Environment Keys/LocaleEnvironmentKey.swift
@@ -12,7 +12,7 @@ extension UIEnvironmentValues {
         set { self[LocaleEnvironmentKey.self] = newValue }
     }
 
-    internal static let setupCurrentLocaleListener: Void = {
+    public static let setupCurrentLocaleListener: Void = {
         NotificationCenter.default.addObserver(
             forName: NSLocale.currentLocaleDidChangeNotification,
             object: nil,

--- a/Sources/UIEnvironment/Predefined Environment Keys/SizeCategoryEnvironmentKey.swift
+++ b/Sources/UIEnvironment/Predefined Environment Keys/SizeCategoryEnvironmentKey.swift
@@ -16,7 +16,7 @@ extension UIEnvironmentValues {
         set { self[SizeCategoryEnvironmentKey.self] = newValue }
     }
 
-    internal static let setupSizeCategoryListener: Void = {
+    public static let setupSizeCategoryListener: Void = {
         NotificationCenter.default.addObserver(
             forName: UIContentSizeCategory.didChangeNotification,
             object: nil,

--- a/Sources/UIEnvironment/UIEnvironment.swift
+++ b/Sources/UIEnvironment/UIEnvironment.swift
@@ -79,10 +79,9 @@ import UIKit
     /// Creates an environment property to read the specified key path.
     /// - Parameter keyPath: A key path to a specific resulting value.
     public init(_ keyPath: KeyPath<UIEnvironmentValues, Value>) {
-        UIScreen.setupTraitCollectionListener
-        UIWindow.setupOverrideUserInterfaceListener
-        UIEnvironmentValues.setupCurrentLocaleListener
-        UIEnvironmentValues.setupSizeCategoryListener
+        if let setupPredefinedEnvironmentListeners = UIEnvironmentValues.setupPredefinedEnvironmentListeners(keyPath) {
+            setupPredefinedEnvironmentListeners()
+        }
         self.keyPath = keyPath
     }
 }

--- a/Sources/UIEnvironment/UIEnvironmentValues+PredefinedListeners.swift
+++ b/Sources/UIEnvironment/UIEnvironmentValues+PredefinedListeners.swift
@@ -1,0 +1,18 @@
+import Foundation
+import UIKit
+
+extension UIEnvironmentValues {
+    /// A closure that is called once for each instance of UIEnvironment passing it's `keyPath`.
+    /// As such, any setup or initialization that has to happens only once, has to be handled internally within this closure.
+    ///
+    /// Use this property to disable or override default environment listeners.
+    ///
+    public static var setupPredefinedEnvironmentListeners: (_ keyPath: AnyKeyPath) -> (() -> Void)? = { _ in
+        {
+            UIScreen.setupTraitCollectionListener
+            UIWindow.setupOverrideUserInterfaceListener
+            UIEnvironmentValues.setupCurrentLocaleListener
+            UIEnvironmentValues.setupSizeCategoryListener
+        }
+    }
+}

--- a/XcodeProject/UIEnvironment.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XcodeProject/UIEnvironment.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "libffi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/623637646/libffi.git",
+      "state" : {
+        "revision" : "bc1dac0c1b522539f21fc28fe1f7e07bb7c2fbd5",
+        "version" : "3.4.5"
+      }
+    },
+    {
+      "identity" : "swifthook",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/623637646/SwiftHook",
+      "state" : {
+        "revision" : "474f80132a3a4e74b3f8a5b87b707d74de387769",
+        "version" : "3.5.2"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
…

* Use `setupPredefinedEnvironmentListeners` to set up custom hooks that observe the system environment changes.
* Make all the existing build-in environment setup-listeners `public` to allow use of them as needed.
* Use `SwiftHook` to safely swizzle the UIKit selectors.
   * This fixes the `UIWindow.overrideUserInterfaceStyle` as internally `SwiftHooks` makes safety checks if an object is capable of calling the swizzled selector.

This should address the issue https://github.com/nonameplum/UIEnvironment/issues/2